### PR TITLE
chore(deps): sync version + safe dependency bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Mixed Media Markdown - Terminal markdown viewer with sixel graphics support",
   "main": "dist/index-direct.js",
   "bin": {
@@ -34,22 +34,22 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@mermaid-js/mermaid-cli": "^11.12.0",
+    "@mermaid-js/mermaid-cli": "^11.15.0",
     "beautiful-mermaid": "^1.1.3",
     "chalk": "^5.3.0",
     "figlet": "^1.7.0",
     "highlight.js": "^11.11.1",
-    "katex": "^0.16.9",
+    "katex": "^0.16.47",
     "marked": "~15.0.12",
     "marked-emoji": "^1.4.3",
     "marked-footnote": "^1.2.4",
-    "marked-highlight": "^2.2.2",
+    "marked-highlight": "^2.2.4",
     "marked-terminal": "^7.3.0",
     "mathjax-full": "^3.2.1",
     "meow": "^13.1.0",
     "node-emoji": "^2.2.0",
     "open": "^10.0.3",
-    "sharp": "^0.33.2"
+    "sharp": "^0.33.5"
   },
   "optionalDependencies": {
     "puppeteer": "^22.0.0"
@@ -57,9 +57,9 @@
   "devDependencies": {
     "@types/figlet": "^1.5.8",
     "@types/jest": "^29.5.11",
-    "@types/node": "^20.11.0",
+    "@types/node": "^20.19.43",
     "jest": "^29.7.0",
-    "tsx": "^4.7.0",
+    "tsx": "^4.22.4",
     "typescript": "^5.3.3"
   },
   "type": "module",


### PR DESCRIPTION
## Changes
- Sync `package.json` version `1.0.6` → `1.1.0` (was lagging the git tag and AUR package)
- Bump safe minor/patch deps: `@mermaid-js/mermaid-cli` 11.12→11.15, `katex` 0.16.9→0.16.47, `sharp` 0.33.2→0.33.5, `tsx` 4.7→4.22, `marked-highlight` 2.2.2→2.2.4, `@types/node` 20.11→20.19

## Security
- Resolves the high-severity `ws` (memory disclosure + DoS) and moderate `uuid` advisories via the mermaid-cli tree bump
- Audit findings: **35 (9 high) → 18 moderate**. Remaining 18 are all in the jest/babel dev chain and require the jest 30 major (deferred)

## Verification
- `npm run build` ✅
- Functional smoke tests ✅ — simple renderer, plus PDF export exercising puppeteer + mermaid-cli + katex + sharp

## Deferred (own branches, per plan)
- `marked` 15→18, `puppeteer` 22→25, `typescript` 5→6, `jest` 29→30 — each touches core rendering/build and needs code changes + testing