### PR TITLE
chore(deps): remove unused jest

### DIFF
--- a/.claude/ways/testing/way.md
+++ b/.claude/ways/testing/way.md
@@ -2,7 +2,7 @@
 description: Testing and verification workflow including PDF output validation and type checking
 vocabulary: test verify check lint pdf-test terminal-test typecheck
 pattern: test|verify|check|lint
-commands: make test|make lint|npm test
+commands: make test-pdf|make test-terminal|make build
 scope: agent, subagent
 ---
 # Testing

--- a/README.md
+++ b/README.md
@@ -301,8 +301,9 @@ npm run build:simple
 # Install locally
 ./scripts/install.sh
 
-# Run tests
-npm test
+# Verify rendering (PDF / terminal)
+make test-pdf
+make test-terminal
 ```
 
 ## 🚦 Terminal Compatibility

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "package": "node scripts/build-binary.js",
     "install:local": "npm run build:binary && ./scripts/install.sh",
     "release:create": "./scripts/create-release.sh",
-    "aur:update": "./scripts/update-aur.sh",
-    "test": "jest"
+    "aur:update": "./scripts/update-aur.sh"
   },
   "keywords": [
     "markdown",
@@ -56,9 +55,7 @@
   },
   "devDependencies": {
     "@types/figlet": "^1.5.8",
-    "@types/jest": "^29.5.11",
     "@types/node": "^20.19.43",
-    "jest": "^29.7.0",
     "tsx": "^4.22.4",
     "typescript": "^5.3.3"
   },


### PR DESCRIPTION
## Changes
- Remove `jest` and `@types/jest` from devDependencies
- Remove the dead `"test": "jest"` script

## Why
jest was entirely unused — no config, no test files, no `@jest` imports, no CI reference. The `test` script ran `jest` and matched zero tests. All 18 remaining moderate audit findings were transitive through this unused harness.

## Result
- **`npm audit`: 0 vulnerabilities** (was 18 moderate)
- `npm run build` ✅
- Lighter install — drops the jest/babel transitive tree

## Note
Closes out the dependency-update sweep's security goal. The TDD Way still applies — when real test coverage begins, re-add jest 30 fresh alongside an actual first test so the harness is proven, not dead.

Remaining deferred majors (separate branches): `typescript` 5→6, `puppeteer` 22→25, `marked` 15→18.