### PR TITLE
chore(deps): upgrade puppeteer 22→25, raise Node baseline to 22.12

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgdesc="Markdown Mixed Media - A powerful terminal markdown viewer with image s
 arch=('any')
 url="https://github.com/aaronsb/markdown-mixed-media"
 license=('MIT')
-depends=('nodejs>=20')
+depends=('nodejs>=22')
 optdepends=(
     'chafa: Terminal image rendering support'
     'mermaid-cli: Mermaid diagram rendering'

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ mmm README.md
 ## 📋 Prerequisites
 
 ### Required
-- **Node.js** v20 or higher (for building)
+- **Node.js** v22.12 or higher (for building; required by puppeteer 25, used for PDF export)
 - **Git** (for cloning)
 
 ### Optional (but recommended)

--- a/package.json
+++ b/package.json
@@ -50,16 +50,16 @@
     "sharp": "^0.33.5"
   },
   "optionalDependencies": {
-    "puppeteer": "^22.0.0"
+    "puppeteer": "^25.1.0"
   },
   "devDependencies": {
     "@types/figlet": "^1.5.8",
-    "@types/node": "^20.19.43",
+    "@types/node": "^22.19.21",
     "tsx": "^4.22.4",
     "typescript": "^5.3.3"
   },
   "type": "module",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.12.0"
   }
 }

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -27,7 +27,7 @@ async function buildBinary() {
       outfile: path.join(projectRoot, 'build/bundle.js'),
       platform: 'node',
       format: 'esm',
-      target: 'node20',
+      target: 'node22',
       // Only exclude native modules that can't be bundled
       external: ['sharp'],  // Keep puppeteer bundled for standalone mermaid rendering
       minify: false,  // Keep it readable for now to debug issues
@@ -115,7 +115,7 @@ import './bundle.js';
   await fs.writeFile(path.join(projectRoot, 'build', 'wrapper.js'), wrapperContent);
 
   // Build with nexe
-  await execAsync(`npx nexe build/wrapper.js -o mmv --target node20-linux-x64`);
+  await execAsync(`npx nexe build/wrapper.js -o mmv --target node22-linux-x64`);
 }
 
 buildBinary();


### PR DESCRIPTION
## Changes
- `puppeteer` (optional) **22 → 25.1.0**
- Node baseline **20 → 22.12** everywhere it's asserted: `engines`, AUR `PKGBUILD` (`nodejs>=22`), README prerequisite, esbuild + nexe build targets
- `@types/node` **20 → 22** to match the new floor

## Why
puppeteer 25 requires Node ≥22.12. Adopting it raises MMM's minimum runtime. puppeteer is the **only** consumer of Chromium now that mermaid-cli was unbundled (ADR-200 Phase 4), and it's an optional dep used solely for PDF export — but `engines` is tool-wide, so the baseline moves for everyone.

**This is a deliberate tradeoff:** it drops Node 20/21 (LTS) support in exchange for currency on the PDF engine. Chosen over staying on puppeteer 24 (which keeps Node ≥18) per maintainer decision.

## Verification
- `npm run build` ✅ (with `@types/node` 22 — no new type errors)
- `npm audit` → **0 vulnerabilities** ✅
- PDF export on puppeteer 25 (Node 26 local) ✅ — mermaid (beautiful-mermaid) + math + tables → valid 1-page PDF
- `npm ls puppeteer` → clean `puppeteer@25.1.0`

## ⚠️ Not verified — needs follow-up
The `build:binary` (nexe) path was **not exercised**. I bumped its target to `node22-linux-x64` for consistency, but nexe's prebuilt node22 binary availability should be confirmed before the next standalone-binary release. The npm + AUR distribution paths (which build from source) are unaffected.

## Note
Dropping an LTS Node version is a product-support decision — happy to formalize the rationale as an ADR if you'd like a durable record beyond this PR + ADR-200.