### PR TITLE
chore(deps): upgrade TypeScript 5→6

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/figlet": "^1.5.8",
     "@types/node": "^22.19.21",
     "tsx": "^4.22.4",
-    "typescript": "^5.3.3"
+    "typescript": "^6.0.3"
   },
   "type": "module",
   "engines": {

--- a/src/index-settings.tsx
+++ b/src/index-settings.tsx
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-import './settings.js';


### PR DESCRIPTION
## Changes
- `typescript` **5.3.3 → 6.0.3** (devDependency)
- Remove dead file `src/index-settings.tsx`

## Why
TypeScript 6.0 added stricter checking for side-effect imports (new diagnostic **TS2882**). The build surfaced exactly one error:

```
src/index-settings.tsx(2,8): error TS2882: Cannot find module or type
declarations for side-effect import of './settings.js'.
```

`index-settings.tsx` is a 2-line orphaned entry-point stub from the initial settings feature (commit 02b5ea2). It does `import './settings.js'` — a module that **never existed** (the real implementation is `settings-cli.ts`). It's referenced nowhere: not in `bin`, not in any npm script, not imported anywhere. The working settings entry is `npm run settings` → `tsx src/settings-cli.ts`.

So TS 6 caught genuinely dead, broken code. Removing it fixes the build and drops the cruft — resurrecting the import would only keep a file nothing uses.

## Verification
- `npm run build` (tsc 6.0.3) ✅ clean
- `npm audit` → **0 vulnerabilities** ✅
- Simple + direct renderers run ✅
- Settings CLI (`settings-cli.ts`) compiles and launches ✅
- tsconfig needed no changes — no legacy flags TS 6 removed (`moduleResolution: bundler`, ES2022, strict)

## Remaining deferred major
- `marked` 15→18 — highest risk; ADR-200 records a marked@17/marked-terminal incompatibility that forced the current pin. Needs its own careful pass.